### PR TITLE
removing admin panel route if necessary

### DIFF
--- a/src/entities/menu/model/index.ts
+++ b/src/entities/menu/model/index.ts
@@ -67,6 +67,24 @@ const getNewNotifications = (page: string, notifications: number, routes: IRoute
     return newRoutes
 }
 
+const filterTeachersPrivateRoutes = (adminLinks: AdminLinks | null): IRoutes => {
+    if (!adminLinks) {
+        return teachersPrivateRoutes()
+    }
+
+    const { accepts, agreements, checkdata, studLogins } = adminLinks
+
+    const hasAdminLinks = !!accepts.length || !!agreements.length || !!checkdata.length || !!studLogins?.length
+
+    const adminRoute = 'download-agreements'
+
+    const filteredRoutes = Object.entries(teachersPrivateRoutes()).filter(
+        ([key]) => key !== adminRoute || (key === adminRoute && hasAdminLinks),
+    )
+
+    return Object.fromEntries(filteredRoutes)
+}
+
 const $menu = createStore<Menu>(DEFAULT_STORE)
     .on(changeOpen, (oldState, { isOpen, currentPage }) => ({
         ...oldState,
@@ -76,26 +94,26 @@ const $menu = createStore<Menu>(DEFAULT_STORE)
     .on(clearStore, () => ({
         ...DEFAULT_STORE,
     }))
-    .on(defineMenu, (oldData, { user, homeRoutes }) => ({
+    .on(defineMenu, (oldData, { user, adminLinks, homeRoutes }) => ({
         ...oldData,
         currentPage:
             user?.user_status === 'staff'
-                ? teachersPrivateRoutes()[window.location.hash.slice(2, window.location.hash.length)]
+                ? filterTeachersPrivateRoutes(adminLinks)[window.location.hash.slice(2, window.location.hash.length)]
                 : privateRoutes()[window.location.hash.slice(2, window.location.hash.length)],
         allRoutes:
             user?.user_status === 'staff'
-                ? { ...teachersPrivateRoutes(), ...teachersHiddenRoutes() }
+                ? { ...filterTeachersPrivateRoutes(adminLinks), ...teachersHiddenRoutes() }
                 : { ...privateRoutes(), ...hiddenRoutes() },
-        visibleRoutes: user?.user_status === 'staff' ? teachersPrivateRoutes() : privateRoutes(),
+        visibleRoutes: user?.user_status === 'staff' ? filterTeachersPrivateRoutes(adminLinks) : privateRoutes(),
         leftsideBarRoutes: findRoutesByConfig(
             getLeftsideBarConfig(user, false),
-            user?.user_status === 'staff' ? teachersPrivateRoutes() : privateRoutes(),
+            user?.user_status === 'staff' ? filterTeachersPrivateRoutes(adminLinks) : privateRoutes(),
         ),
         homeRoutes: findRoutesByConfig(
             homeRoutes ??
                 (JSON.parse(localStorage.getItem('home-routes') ?? JSON.stringify(DEFAULT_HOME_CONFIG)) as string[]),
             user?.user_status === 'staff'
-                ? { ...teachersPrivateRoutes(), ...teachersHiddenRoutes() }
+                ? { ...filterTeachersPrivateRoutes(adminLinks), ...teachersHiddenRoutes() }
                 : { ...privateRoutes(), ...hiddenRoutes() },
         ),
     }))


### PR DESCRIPTION
Добавлен метод, который фильтрует разделы сотрудников в зависимости от того, есть ли у пользователя данные хотя бы в одном из разделов админ-панели: 'Анкета'/'Акцепт'/'Доп. соглашения'/'Логины студентов'. Если данных нет, раздел админ-панели не отображается